### PR TITLE
Remove Apache Commons Lang3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,6 @@ repositories {
 dependencies {
     implementation("net.java.dev.jna:jna:5.10.0")
     implementation("io.arrow-kt:arrow-core:1.0.1")
-    implementation("org.apache.commons:commons-lang3:3.12.0")
 }
 
 tasks.withType<KotlinCompile>() {

--- a/src/main/kotlin/tv/wunderbox/nfd/nfd/NfdFileDialog.kt
+++ b/src/main/kotlin/tv/wunderbox/nfd/nfd/NfdFileDialog.kt
@@ -5,7 +5,6 @@ import arrow.core.left
 import arrow.core.right
 import com.sun.jna.*
 import com.sun.jna.ptr.PointerByReference
-import org.apache.commons.lang3.SystemUtils
 import tv.wunderbox.nfd.FileDialog
 import tv.wunderbox.nfd.nfd.jna.*
 import java.io.File
@@ -89,7 +88,7 @@ class NfdFileDialog : FileDialog {
         if (countResult != NfdResult.NFD_OKAY)
             return FileDialog.Error.ERROR.left()
         val count = try {
-            if (SystemUtils.IS_OS_LINUX) {
+            if (Platform.isLinux()) {
                 countPointer
                     .getInt(0L)
             } else {

--- a/src/main/kotlin/tv/wunderbox/nfd/nfd/jna/NfdLibraryNative.kt
+++ b/src/main/kotlin/tv/wunderbox/nfd/nfd/jna/NfdLibraryNative.kt
@@ -1,7 +1,6 @@
 package tv.wunderbox.nfd.nfd.jna
 
 import com.sun.jna.*
-import org.apache.commons.lang3.SystemUtils
 import java.io.File
 import java.nio.file.Files
 
@@ -14,12 +13,9 @@ private const val NFD_OS_FILE_FILENAME = "libnfd"
 
 private val libraryFile by lazy {
     val filename = when {
-        SystemUtils.IS_OS_WINDOWS ->
-            NFD_RES_FILENAME_WIN
-        SystemUtils.IS_OS_MAC || SystemUtils.IS_OS_MAC_OSX ->
-            NFD_RES_FILENAME_MAC
-        SystemUtils.IS_OS_LINUX ->
-            NFD_RES_FILENAME_LINUX
+        Platform.isWindows() -> NFD_RES_FILENAME_WIN
+        Platform.isMac() -> NFD_RES_FILENAME_MAC
+        Platform.isLinux() -> NFD_RES_FILENAME_LINUX
         else -> throw IllegalArgumentException()
     }
     extractLibrary(filename)


### PR DESCRIPTION
Apache Commons Lang3 is an unnecessary dependency and all usages of SystemUtils can be replaced with JNA's `Platform` class (`Platform.isWindows()`, `Platform.isLinux()`, etc).