### PR TITLE
Enable explicit API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,10 @@ repositories {
     mavenCentral()
 }
 
+kotlin {
+    explicitApi()
+}
+
 dependencies {
     implementation("net.java.dev.jna:jna:5.13.0")
     implementation("io.arrow-kt:arrow-core:1.0.1")

--- a/src/main/kotlin/tv/wunderbox/nfd/FileDialog.kt
+++ b/src/main/kotlin/tv/wunderbox/nfd/FileDialog.kt
@@ -6,13 +6,13 @@ import tv.wunderbox.nfd.nfd.NfdFileDialog
 import java.awt.Component
 import java.io.File
 
-interface FileDialog {
-    companion object {
+public interface FileDialog {
+    public companion object {
         /**
          * Default implementation tries to open the native file dialog, and
          * falls back to the AWT file dialog if that.
          */
-        fun default(
+        public fun default(
             window: Component,
         ): FileDialog = kotlin.run {
             val nfd = NfdFileDialog()
@@ -23,38 +23,38 @@ interface FileDialog {
         }
     }
 
-    fun save(
+    public fun save(
         filters: List<Filter> = emptyList(),
         defaultPath: String? = null,
         defaultName: String? = null,
     ): Either<Error, File>
 
-    fun pickFile(
+    public fun pickFile(
         filters: List<Filter> = emptyList(),
         defaultPath: String? = null,
     ): Either<Error, File>
 
-    fun pickFileMany(
+    public fun pickFileMany(
         filters: List<Filter> = emptyList(),
         defaultPath: String? = null,
     ): Either<Error, List<File>>
 
-    fun pickDirectory(
+    public fun pickDirectory(
         defaultPath: String? = null,
     ): Either<Error, File>
 
-    enum class Error {
+    public enum class Error {
         ERROR,
         CANCEL,
     }
 
-    data class Filter(
+    public data class Filter(
         val title: String,
         val extensions: List<String>,
     )
 }
 
-fun FileDialog.fallbackWith(nfd: FileDialog): FileDialog =
+public fun FileDialog.fallbackWith(nfd: FileDialog): FileDialog =
     object : FileDialog {
         override fun save(
             filters: List<FileDialog.Filter>,

--- a/src/main/kotlin/tv/wunderbox/nfd/awt/AwtFileDialog.kt
+++ b/src/main/kotlin/tv/wunderbox/nfd/awt/AwtFileDialog.kt
@@ -12,7 +12,7 @@ import javax.swing.filechooser.FileFilter
 /**
  * @author Artem Chepurnoy
  */
-class AwtFileDialog(
+public class AwtFileDialog(
     private val window: Component,
     private val title: String? = null,
 ) : FileDialog {

--- a/src/main/kotlin/tv/wunderbox/nfd/nfd/NfdFileDialog.kt
+++ b/src/main/kotlin/tv/wunderbox/nfd/nfd/NfdFileDialog.kt
@@ -9,7 +9,7 @@ import tv.wunderbox.nfd.FileDialog
 import tv.wunderbox.nfd.nfd.jna.*
 import java.io.File
 
-class NfdFileDialog : FileDialog {
+public class NfdFileDialog : FileDialog {
     override fun save(
         filters: List<FileDialog.Filter>,
         defaultPath: String?,

--- a/src/main/kotlin/tv/wunderbox/nfd/nfd/jna/NfdLibraryNative.kt
+++ b/src/main/kotlin/tv/wunderbox/nfd/nfd/jna/NfdLibraryNative.kt
@@ -41,12 +41,12 @@ private fun extractLibrary(filename: String): File {
     return outFile
 }
 
-interface NfdLibraryNative : Library, NfdLibraryNativeApi {
-    companion object {
+public interface NfdLibraryNative : Library, NfdLibraryNativeApi {
+    public companion object {
         @Volatile
         private var instance: NfdLibraryNativeApi? = null
 
-        fun get(): NfdLibraryNativeApi {
+        public fun get(): NfdLibraryNativeApi {
             if (instance == null) {
                 synchronized(NfdLibraryNative::class.java) {
                     if (instance == null) {

--- a/src/main/kotlin/tv/wunderbox/nfd/nfd/jna/NfdLibraryNativeApi.kt
+++ b/src/main/kotlin/tv/wunderbox/nfd/nfd/jna/NfdLibraryNativeApi.kt
@@ -3,16 +3,16 @@ package tv.wunderbox.nfd.nfd.jna
 import com.sun.jna.*
 import com.sun.jna.ptr.PointerByReference
 
-interface NfdLibraryNativeApi {
+public interface NfdLibraryNativeApi {
     /**
      * Initialize NFD - call this for every thread that might use NFD, before calling any other NFD
      * functions on that thread
      */
-    fun NFD_Init(
+    public fun NFD_Init(
     ): NfdResult
 
     /** Call this to de-initialize NFD, if NFD_Init returned NFD_OKAY */
-    fun NFD_Quit()
+    public fun NFD_Quit()
 
     /**
      * Single file open dialog
@@ -23,7 +23,7 @@ interface NfdLibraryNativeApi {
      * If filterCount is zero, filterList is ignored (you can use NULL)
      * If defaultPath is NULL, the operating system will decide
      */
-    fun NFD_OpenDialogN(
+    public fun NFD_OpenDialogN(
         outPath: PointerByReference,
         filterList: Pointer?,
         filterCount: NativeLong,
@@ -39,7 +39,7 @@ interface NfdLibraryNativeApi {
      * If filterCount is zero, filterList is ignored (you can use NULL)
      * If defaultPath is NULL, the operating system will decide
      */
-    fun NFD_OpenDialogMultipleN(
+    public fun NFD_OpenDialogMultipleN(
         outPaths: PointerByReference,
         filterList: Pointer?,
         filterCount: NativeLong,
@@ -55,7 +55,7 @@ interface NfdLibraryNativeApi {
      * If filterCount is zero, filterList is ignored (you can use NULL)
      * If defaultPath is NULL, the operating system will decide
      */
-    fun NFD_SaveDialogN(
+    public fun NFD_SaveDialogN(
         outPath: PointerByReference,
         filterList: Pointer?,
         filterCount: NativeLong,
@@ -71,11 +71,11 @@ interface NfdLibraryNativeApi {
      *
      * If defaultPath is NULL, the operating system will decide
      */
-    fun NFD_PickFolderN(outPath: PointerByReference, defaultPath: Pointer?): NfdResult
+    public fun NFD_PickFolderN(outPath: PointerByReference, defaultPath: Pointer?): NfdResult
 
-    fun NFD_PathSet_Free(pathSet: Pointer)
+    public fun NFD_PathSet_Free(pathSet: Pointer)
 
-    fun NFD_FreePathN(filePath: Pointer)
+    public fun NFD_FreePathN(filePath: Pointer)
 
     /**
      * Gets the number of entries stored in pathSet
@@ -83,7 +83,7 @@ interface NfdLibraryNativeApi {
      * note that some paths might be invalid (NFD_ERROR will be returned by NFD_PathSet_GetPath), so we
      * might not actually have this number of usable paths
      */
-    fun NFD_PathSet_GetCount(
+    public fun NFD_PathSet_GetCount(
         pathSet: Pointer,
         count: Pointer,
     ): NfdResult
@@ -94,7 +94,7 @@ interface NfdLibraryNativeApi {
      * It is the caller's responsibility to free `outPath` via NFD_PathSet_FreePathN() if this function
      * returns NFD_OKAY
      */
-    fun NFD_PathSet_GetPathN(
+    public fun NFD_PathSet_GetPathN(
         pathSet: Pointer,
         index: Long,
         outPath: PointerByReference,

--- a/src/main/kotlin/tv/wunderbox/nfd/nfd/jna/NfdResult.kt
+++ b/src/main/kotlin/tv/wunderbox/nfd/nfd/jna/NfdResult.kt
@@ -3,7 +3,7 @@ package tv.wunderbox.nfd.nfd.jna
 import com.sun.jna.FromNativeContext
 import com.sun.jna.NativeMapped
 
-enum class NfdResult : NativeMapped {
+public enum class NfdResult : NativeMapped {
     NFD_ERROR, /* programmatic error */
     NFD_OKAY, /* user pressed okay, or successful return */
     NFD_CANCEL; /* user pressed cancel */


### PR DESCRIPTION
Kotlin 1.4.0 added [explicit API mode](https://kotlinlang.org/docs/whatsnew14.html#explicit-api-mode-for-library-authors) which is part of the [best practice for libraries](https://kotlinlang.org/docs/jvm-api-guidelines-backward-compatibility.html#explicit-api-mode).

This enforces visibility and type declarations.

> Kotlin compiler offers explicit API mode for library authors. In this mode, the compiler performs additional checks that help make the library's API clearer and more consistent. It adds the following requirements for declarations exposed to the library's public API:

> Visibility modifiers are required for declarations if the default visibility exposes them to the public API. This helps ensure that no declarations are exposed to the public API unintentionally.

> Explicit type specifications are required for properties and functions that are exposed to the public API. This guarantees that API users are aware of the types of API members they use.