### PR TITLE
Add extensions to FileDialogResult

### DIFF
--- a/src/main/kotlin/tv/wunderbox/nfd/FileDialogResult.kt
+++ b/src/main/kotlin/tv/wunderbox/nfd/FileDialogResult.kt
@@ -13,6 +13,15 @@ public sealed interface FileDialogResult<out T> {
      */
     public val isFailure: Boolean get() = this is Failure
 
+    /**
+     * Returns the encapsulated value if this instance represents [success][isSuccess] or `null`
+     * if it is [failure][isFailure].
+     */
+    public fun getOrNull(): T? = when (this) {
+        is Success -> value
+        is Failure -> null
+    }
+
     public data class Failure(
         val error: FileDialog.Error,
     ) : FileDialogResult<Nothing>

--- a/src/main/kotlin/tv/wunderbox/nfd/FileDialogResult.kt
+++ b/src/main/kotlin/tv/wunderbox/nfd/FileDialogResult.kt
@@ -7,6 +7,12 @@ public sealed interface FileDialogResult<out T> {
      */
     public val isSuccess: Boolean get() = this !is Failure
 
+    /**
+     * Returns `true` if this instance represents a failed outcome.
+     * In this case [isSuccess] returns `false`.
+     */
+    public val isFailure: Boolean get() = this is Failure
+
     public data class Failure(
         val error: FileDialog.Error,
     ) : FileDialogResult<Nothing>

--- a/src/main/kotlin/tv/wunderbox/nfd/FileDialogResult.kt
+++ b/src/main/kotlin/tv/wunderbox/nfd/FileDialogResult.kt
@@ -1,6 +1,12 @@
 package tv.wunderbox.nfd
 
 public sealed interface FileDialogResult<out T> {
+    /**
+     * Returns `true` if this instance represents a successful outcome.
+     * In this case [isFailure] returns `false`.
+     */
+    public val isSuccess: Boolean get() = this !is Failure
+
     public data class Failure(
         val error: FileDialog.Error,
     ) : FileDialogResult<Nothing>

--- a/src/main/kotlin/tv/wunderbox/nfd/FileDialogResult.kt
+++ b/src/main/kotlin/tv/wunderbox/nfd/FileDialogResult.kt
@@ -22,11 +22,19 @@ public sealed interface FileDialogResult<out T> {
         is Failure -> null
     }
 
-    public data class Failure(
-        val error: FileDialog.Error,
-    ) : FileDialogResult<Nothing>
+    public class Failure(
+        public val error: FileDialog.Error,
+    ) : FileDialogResult<Nothing> {
+        override fun equals(other: Any?): Boolean = other is Failure && error == other.error
+        override fun hashCode(): Int = error.hashCode()
+        override fun toString(): String = "Failure(${error.name})"
+    }
 
-    public data class Success<T>(
-        val value: T,
-    ) : FileDialogResult<T>
+    public class Success<T>(
+        public val value: T,
+    ) : FileDialogResult<T> {
+        override fun equals(other: Any?): Boolean = other is Success<*> && value == other.value
+        override fun hashCode(): Int = value.hashCode()
+        override fun toString(): String = "Success(value=$value)"
+    }
 }

--- a/src/main/kotlin/tv/wunderbox/nfd/FileDialogResult.kt
+++ b/src/main/kotlin/tv/wunderbox/nfd/FileDialogResult.kt
@@ -5,7 +5,7 @@ public sealed interface FileDialogResult<out T> {
      * Returns `true` if this instance represents a successful outcome.
      * In this case [isFailure] returns `false`.
      */
-    public val isSuccess: Boolean get() = this !is Failure
+    public val isSuccess: Boolean get() = this is Success
 
     /**
      * Returns `true` if this instance represents a failed outcome.


### PR DESCRIPTION
- Adds the [isSuccess](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-result/is-success.html) and [isFailure](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-result/is-failure.html) properties from the Kotlin [Result](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-result) class. The Kotlin Result class puts these as [discovery properties](https://github.com/JetBrains/kotlin/blob/924c28507067cbfbf78a6509ea89eabe496e34ca/libraries/stdlib/src/kotlin/util/Result.kt#L26).
- Adds [getOrNull](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-result/get-or-null.html) that returns the value if there is not an error, or null otherwise.
- Replaces the Success and Failure data classes with regular classes. This is because using data classes in public API is part of Kotlin's [don't do recommendations](https://kotlinlang.org/docs/jvm-api-guidelines-backward-compatibility.html).
   - https://kotlinlang.org/docs/jvm-api-guidelines-backward-compatibility.html#don-t-use-data-classes-in-api:
   > [Data classes](https://kotlinlang.org/docs/data-classes.html) are tempting to use because they are short, concise, and have some functionality out of the box. However, due to some specifics of how data classes work, it's better not to use them in library APIs. Almost any change makes the API not backward compatible.