### PR TITLE
Add libs.versions.toml

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-    kotlin("jvm") version "1.8.22"
-    id("maven-publish")
-    id("signing")
+    alias(libs.plugins.kotlin)
+    `maven-publish`
+    signing
 }
 
 group = "tv.wunderbox"
@@ -22,7 +22,8 @@ kotlin {
 }
 
 dependencies {
-    implementation("net.java.dev.jna:jna:5.13.0")
+    // JNA - https://github.com/java-native-access/jna
+    implementation(libs.jna)
 }
 
 // See:

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,0 +1,9 @@
+[versions]
+jna = "5.13.0"
+kotlin = "1.8.22"
+
+[libraries]
+jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
+
+[plugins]
+kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,9 @@
-
 rootProject.name = "nativefiledialog-java"
 
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("libs.versions.toml"))
+        }
+    }
+}


### PR DESCRIPTION
This adds a [libs.versions.toml](https://docs.gradle.org/current/userguide/platforms.html#sub:conventional-dependencies-toml) file to keep dependency names and versions in one place.