### PR TITLE
Update to Kotlin 1.9.0

### DIFF
--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 jna = "5.13.0"
-kotlin = "1.8.22"
+kotlin = "1.9.0"
 
 [libraries]
 jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }

--- a/src/main/kotlin/tv/wunderbox/nfd/nfd/NfdFileDialog.kt
+++ b/src/main/kotlin/tv/wunderbox/nfd/nfd/NfdFileDialog.kt
@@ -100,7 +100,7 @@ public class NfdFileDialog : FileDialog {
             return FileDialogResult.Failure(FileDialog.Error.ERROR)
         }
 
-        val files = (0 until count)
+        val files = (0..<count)
             .map { index ->
                 val outPathPointer = PointerByReference()
                 val pathResult = nfd.NFD_PathSet_GetPathN(

--- a/src/main/kotlin/tv/wunderbox/nfd/nfd/jna/NfdResult.kt
+++ b/src/main/kotlin/tv/wunderbox/nfd/nfd/jna/NfdResult.kt
@@ -9,7 +9,7 @@ public enum class NfdResult : NativeMapped {
     NFD_CANCEL; /* user pressed cancel */
 
     override fun fromNative(nativeValue: Any?, context: FromNativeContext?): Any {
-        return values()[nativeValue as Int]
+        return entries[nativeValue as Int]
     }
 
     override fun toNative(): Any = ordinal


### PR DESCRIPTION
- Updates Kotlin to 1.9.0
- Replaces `until` with [Kotlin 1.9.0 open-ended range operator](https://kotlinlang.org/docs/whatsnew-eap.html#stable-operator-for-open-ended-ranges) (`..<`)
- Replaces `values()` with [Kotlin 1.9.0 `entries`](https://kotlinlang.org/docs/whatsnew-eap.html#stable-replacement-of-the-enum-class-values-function)